### PR TITLE
Added cookie to upload_spec.py

### DIFF
--- a/automation/upload_spec.py
+++ b/automation/upload_spec.py
@@ -163,6 +163,9 @@ def main():
     # Add Auth Header by default to all requests.
     REQUEST.headers.update({'Authorization': 'Bearer {}'.format(access_token)})
 
+    # This seems to be expected as of 26/7/2024
+    REQUEST.cookies.update({'access_token': access_token})
+
     # Retrieve all the API specs
     folder = get_specs_folder(org_name)
 


### PR DESCRIPTION
Some apigee calls are now expecting a cookie.  Added `access_token` cookie